### PR TITLE
Request Callback fixes.

### DIFF
--- a/Oxide.Ext.Discord/DiscordObjects/Message.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Message.cs
@@ -46,7 +46,7 @@
 
         public void Reply(DiscordClient client, Message message, bool ping = true, Action<Message> callback = null)
         {
-            message.content = ping ? $"<@{author.id}> {message.content}" : message.content;
+            message.content = ping ? message.content.Contains($"<@{author.id}>") ? message.content : $" <@{author.id}> {message.content}" : message.content;
 
             client.REST.DoRequest($"/channels/{channel_id}/messages", RequestMethod.POST, message, callback);
         }

--- a/Oxide.Ext.Discord/REST/Request.cs
+++ b/Oxide.Ext.Discord/REST/Request.cs
@@ -108,7 +108,15 @@
 
             response.Close();
 
-            Callback?.Invoke(this.Response);
+            try
+            {
+                Callback?.Invoke(this.Response);
+            }
+            catch (Exception ex)
+            {
+                Interface.Oxide.LogException("[Discord Ext] Request callback raised an exception", ex);
+                this.Close();
+            }
 
             this.Close();
         }


### PR DESCRIPTION
When an exception was made inside of a callback the request was unable to close as the this.Close() was unreachable causing the extension to halt requiring a server restart to fix.

The issue is now fixed and have tested it locally.

http://i.memesquad.nz/a/0Zznqs.png