### PR TITLE
Request fixes.

### DIFF
--- a/Oxide.Ext.Discord/DiscordObjects/Message.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Message.cs
@@ -46,7 +46,7 @@
 
         public void Reply(DiscordClient client, Message message, bool ping = true, Action<Message> callback = null)
         {
-            message.content = ping ? message.content.Contains($"<@{author.id}>") ? message.content : $" <@{author.id}> {message.content}" : message.content;
+            message.content = ping ? message.content != null && message.content.Contains($"<@{author.id}>") ? message.content : $" <@{author.id}> {message.content}" : message.content;
 
             client.REST.DoRequest($"/channels/{channel_id}/messages", RequestMethod.POST, message, callback);
         }

--- a/Oxide.Ext.Discord/REST/Request.cs
+++ b/Oxide.Ext.Discord/REST/Request.cs
@@ -89,8 +89,13 @@
                     message = reader.ReadToEnd().Trim();
                 }
 
+                if (int.Parse(httpResponse.StatusCode.ToString()) == 429)
+                {
+                    httpResponse.Close();
+                    this.InProgress = false;
+                    return;
+                }
                 Interface.Oxide.LogWarning($"[Discord Ext] An error occured whilst submitting a request to {req.RequestUri} (code {httpResponse.StatusCode}): {message}");
-
                 httpResponse.Close();
                 this.Close();
                 return;


### PR DESCRIPTION
If a request was made under ratelimit it would get removed from bucket rather than staying in the queue, it should now only remove requests that shouldn't be sent again such as 404's. 

I've also moved the LogWarning to only log warnings if the exception isn't a ratelimit.