### PR TITLE
[SocketListener] Don't reopen if server is shutting down.

### DIFF
--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -58,7 +58,7 @@ namespace Oxide.Ext.Discord.WebSockets
                 throw new APIKeyException();
             }
                     
-            if (!e.WasClean || e.Code == 1001 || client.AutoReconnect)
+            if ((!e.WasClean || e.Code == 1001 || client.AutoReconnect) && !Interface.Oxide.IsShuttingDown)
             {
                 if (!e.WasClean)
                 {


### PR DESCRIPTION
```
12:00 [Info] [Discord Ext] Disconnected all clients - server shutdown.
12:00 PM [Warning] [Discord Ext] Discord connection closed: code 1005, Reason: 
12:00 PM [Warning] [Discord Ext] Attempting to reconnect to Discord...
12:00 PM [Warning] [Discord Ext] An error has occured: Response: An exception has occurred during the OnClose event.
12:00 PM [Warning] [Discord Ext] Discord connection closed: code 1005, Reason: 
12:00 PM [Warning] [Discord Ext] Attempting to reconnect to Discord...
12:00 PM [Warning] [Discord Ext] An error has occured: Response: An exception has occurred during the OnClose event.
12:00 [Info] Loading Oxide Core v2.0.3773...
```

Extension reopening during restart, lemme know if there's a better way of doing so.