### PR TITLE
Add OnPluginUnload handling, and new optional settings class.

### DIFF
--- a/Oxide.Ext.Discord/Discord.cs
+++ b/Oxide.Ext.Discord/Discord.cs
@@ -9,7 +9,7 @@
     {
         public static List<DiscordClient> Clients { get; private set; } = new List<DiscordClient>();
 
-        public static void CreateClient(Plugin plugin, string apiKey)
+        public static void CreateClient(Plugin plugin, string apiKey, OptionalSettings settings)
         {
             if (plugin == null)
             {
@@ -35,6 +35,7 @@
 
                 client.RegisterPlugin(plugin);
                 client.UpdatePluginReference(plugin);
+                client.RegisterSettings(settings);
                 client.CallHook("DiscordSocket_Initialized", plugin);
                 return;
             }

--- a/Oxide.Ext.Discord/DiscordClient.cs
+++ b/Oxide.Ext.Discord/DiscordClient.cs
@@ -34,6 +34,13 @@ namespace Oxide.Ext.Discord
 
         private int lastHeartbeat;
 
+        public OptionalSettings OptionalSettings { get; set; }
+
+        public void RegisterSettings(OptionalSettings settings)
+        {
+            this.OptionalSettings = settings;
+        }
+
         public void Initialize(Plugin plugin, string apiKey)
         {
             if (string.IsNullOrEmpty(apiKey))

--- a/Oxide.Ext.Discord/DiscordExtension.cs
+++ b/Oxide.Ext.Discord/DiscordExtension.cs
@@ -5,6 +5,7 @@
     using System.Reflection;
     using Oxide.Core;
     using Oxide.Core.Extensions;
+    using Oxide.Core.Plugins;
 
     public class DiscordExtension : Extension
     {
@@ -26,6 +27,33 @@
             {
                 Interface.Oxide.LogException("An exception was thrown!", exception.ExceptionObject as Exception);
             };
+        }
+
+        [HookMethod("OnPluginUnloaded")]
+        void OnPluginUnloaded(Plugin name)
+        {
+            foreach (var client in new List<DiscordClient>(Discord.Clients))
+            {
+                if (client.OptionalSettings.KeepLoadedAfterUnload) continue;
+                if (client.Plugins.Count == 1)
+                {
+                    if (client.Plugins[0] != name) continue;
+                    if (client.OptionalSettings.ExtensiveLogging) Interface.Oxide.LogWarning($"[Discord Ext] Shutting down discord bot registered for plugin {name.Name} as it was set to disconnect upon unload.");
+                    Discord.CloseClient(client);
+                    continue;
+                }
+                if(client.Plugins.Count == 0)
+                {
+                    Discord.CloseClient(client);
+                    continue;
+                }
+
+                if (client.Plugins.Contains(name))
+                {
+                    if (client.OptionalSettings.ExtensiveLogging) Interface.Oxide.LogWarning($"[Discord Ext] Handling plugin unload for plugin {name.Name}.");
+                    client.Plugins.Remove(name);
+                }
+            }
         }
 
         public override void OnShutdown()

--- a/Oxide.Ext.Discord/OptionalSettings.cs
+++ b/Oxide.Ext.Discord/OptionalSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Oxide.Ext.Discord
+{
+    public class OptionalSettings
+    {
+        public bool KeepLoadedAfterUnload;
+        public bool ExtensiveLogging;
+    }
+}

--- a/Oxide.Ext.Discord/Oxide.Ext.Discord.csproj
+++ b/Oxide.Ext.Discord/Oxide.Ext.Discord.csproj
@@ -97,6 +97,7 @@
     <Compile Include="DiscordObjects\Nick.cs" />
     <Compile Include="DiscordObjects\ObjectPosition.cs" />
     <Compile Include="DiscordObjects\WebhookPayload.cs" />
+    <Compile Include="OptionalSettings.cs" />
     <Compile Include="REST\Bucket.cs" />
     <Compile Include="REST\GlobalRateLimit.cs" />
     <Compile Include="REST\Request.cs" />


### PR DESCRIPTION
This adds a OptionalSettings class, along with plugin unload handling. This allows it so that when a plugin unloads, the discord bot will discord as well. Unless there is more than one plugin supporting the bot. This can probably be cleaned up and put into the DiscordSettings class, but this is for an example of what is possible.