### PR TITLE
Add Resuming & Auto Reconnecting.

### DIFF
--- a/Oxide.Ext.Discord/DiscordClient.cs
+++ b/Oxide.Ext.Discord/DiscordClient.cs
@@ -168,7 +168,6 @@ namespace Oxide.Ext.Discord
         private void HeartbeatElapsed(object sender, ElapsedEventArgs e)
         {
             if (!webSocket.IsAlive() || 
-                webSocket.IsClosed() || 
                 webSocket.IsClosed())
             {
                 timer.Dispose();

--- a/Oxide.Ext.Discord/DiscordEvents/Resume.cs
+++ b/Oxide.Ext.Discord/DiscordEvents/Resume.cs
@@ -1,0 +1,11 @@
+﻿namespace Oxide.Ext.Discord.DiscordEvents
+{
+    public class Resume
+    {
+        public string token { get; set; }
+        
+        public string session_id { get; set; }
+
+        public int seq { get; set; }
+    }
+}

--- a/Oxide.Ext.Discord/DiscordObjects/Channel.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Channel.cs
@@ -3,12 +3,19 @@
     using System;
     using System.Collections.Generic;
     using Oxide.Ext.Discord.REST;
-
+    public enum ChannelType
+    {
+        GUILD_TEXT = 0,
+        DM = 1,
+        GUILD_VOICE = 2,
+        GROUP_DM = 3,
+        GUILD_CATEGORY = 4
+    }
     public class Channel
     {
         public string id { get; set; }
 
-        public int? type { get; set; }
+        public ChannelType type { get; set; }
 
         public int? position { get; set; }
 
@@ -30,7 +37,7 @@
         {
             client.REST.DoRequest($"/channels/{channelID}", RequestMethod.GET, null, callback);
         }
-        
+
         public void ModifyChannel(DiscordClient client, Channel newChannel, Action<Channel> callback = null)
         {
             client.REST.DoRequest($"/channels/{id}", RequestMethod.PATCH, newChannel, callback);

--- a/Oxide.Ext.Discord/DiscordObjects/Guild.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Guild.cs
@@ -8,7 +8,7 @@
     public class Guild
     {
         public string id { get; set; }
-        
+
         public string name { get; set; }
 
         public string icon { get; set; }
@@ -101,7 +101,7 @@
 
         public void CreateGuildChannel(DiscordClient client, Channel channel, Action<Channel> callback = null) => CreateGuildChannel(client, channel.name, channel.type, channel.bitrate, channel.user_limit, channel.permission_overwrites, callback);
 
-        public void CreateGuildChannel(DiscordClient client, string name, int? type, int? bitrate, int? userLimit, List<Overwrite> permissionOverwrites, Action<Channel> callback = null)
+        public void CreateGuildChannel(DiscordClient client, string name, ChannelType type, int? bitrate, int? userLimit, List<Overwrite> permissionOverwrites, Action<Channel> callback = null)
         {
             var jsonObj = new Dictionary<string, object>()
             {
@@ -111,7 +111,6 @@
                 { "user_limit", userLimit },
                 { "permission_overwrites", permissionOverwrites }
             };
-
             client.REST.DoRequest($"/guilds/{id}/channels", RequestMethod.POST, jsonObj, callback);
         }
 
@@ -209,7 +208,7 @@
 
             client.REST.DoRequest($"/guilds/{id}/bans/{userID}", RequestMethod.PUT, jsonObj, callback);
         }
-        
+
         public void RemoveGuildBan(DiscordClient client, string userID, Action callback = null)
         {
             client.REST.DoRequest($"/guilds/{id}/bans/{userID}", RequestMethod.DELETE, null, callback);

--- a/Oxide.Ext.Discord/DiscordObjects/Message.cs
+++ b/Oxide.Ext.Discord/DiscordObjects/Message.cs
@@ -5,7 +5,17 @@
     using System.Text;
     using Oxide.Ext.Discord.Helpers;
     using Oxide.Ext.Discord.REST;
-
+    public enum MessageType
+    {
+        DEFAULT = 0,
+        RECIPIENT_ADD = 1,
+        RECIPIENT_REMOVE = 2,
+        CALL = 3,
+        CHANNEL_NAME_CHANGE = 4,
+        CHANNEL_ICON_CHANGE = 5,
+        CHANNEL_PINNED_MESSAGE = 6,
+        GUILD_MEMBER_JOIN = 7
+    }
     public class Message
     {
         public string id { get; set; }
@@ -42,7 +52,7 @@
 
         public string webhook_id { get; set; }
 
-        public int? type { get; set; }
+        public MessageType type { get; set; }
 
         public void Reply(DiscordClient client, Message message, bool ping = true, Action<Message> callback = null)
         {

--- a/Oxide.Ext.Discord/Oxide.Ext.Discord.csproj
+++ b/Oxide.Ext.Discord/Oxide.Ext.Discord.csproj
@@ -41,6 +41,7 @@
     <Compile Include="DiscordEvents\GuildBan.cs" />
     <Compile Include="DiscordEvents\GuildMemberAdd.cs" />
     <Compile Include="DiscordEvents\GuildMemberRemove.cs" />
+    <Compile Include="DiscordEvents\Resume.cs" />
     <Compile Include="DiscordEvents\TypingStart.cs" />
     <Compile Include="DiscordEvents\VoiceServerUpdate.cs" />
     <Compile Include="DiscordEvents\WebhooksUpdate.cs" />

--- a/Oxide.Ext.Discord/WebSockets/Socket.cs
+++ b/Oxide.Ext.Discord/WebSockets/Socket.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Oxide.Ext.Discord.Exceptions;
+    using Oxide.Ext.Discord.DiscordEvents;
     using WebSocketSharp;
 
     public class Socket
@@ -9,6 +10,12 @@
         private DiscordClient client;
 
         private WebSocket socket;
+        
+        public int reconnectAttempts = 0;
+
+        public Resume resume;
+
+        public int lastHeartbeat = 0;
 
         private SocketListner listner;
 

--- a/Oxide.Ext.Discord/WebSockets/Socket.cs
+++ b/Oxide.Ext.Discord/WebSockets/Socket.cs
@@ -37,7 +37,6 @@
             socket.OnClose += listner.SocketClosed;
             socket.OnError += listner.SocketErrored;
             socket.OnMessage += listner.SocketMessage;
-
             socket.ConnectAsync();
         }
 

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -76,14 +76,13 @@ namespace Oxide.Ext.Discord.WebSockets
             if (!Interface.Oxide.IsShuttingDown)
             {
                 Interface.Oxide.LogWarning($"[Discord Ext] Connection closed.. CODE: {e.Code}");
-                Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect to Discord...");
 
                 webSocket.reconnectAttempts++;
                     int interval = webSocket.reconnectAttempts < 50 ? 3 : webSocket.reconnectAttempts < 100 ?  10 : 60;
                     reconnectTimer.Interval = (interval*1000);
                     reconnectTimer.Elapsed += ConnectTimer;
                     reconnectTimer.Start();
-                    Interface.Oxide.LogWarning($"[Discord Ext] Reconnecting in {interval} seconds...");
+                    Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect in {interval} seconds...");
             }
 
             client.CallHook("DiscordSocket_WebSocketClosed", null, e.Reason, e.Code, e.WasClean);

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -147,6 +147,7 @@ namespace Oxide.Ext.Discord.WebSockets
                                 {
                                     Ready ready = JsonConvert.DeserializeObject<Ready>(eventData);
                                     resume.session_id = ready.session_id;
+                                    resume.token = client.Settings.ApiToken;
                                     client.CallHook("Discord_Ready", null, ready);
                                     break;
                                 }

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -78,11 +78,11 @@ namespace Oxide.Ext.Discord.WebSockets
                 Interface.Oxide.LogWarning($"[Discord Ext] Connection closed.. CODE: {e.Code}");
 
                 webSocket.reconnectAttempts++;
-                    int interval = webSocket.reconnectAttempts < 50 ? 3 : webSocket.reconnectAttempts < 100 ?  10 : 60;
-                    reconnectTimer.Interval = (interval*1000);
-                    reconnectTimer.Elapsed += ConnectTimer;
-                    reconnectTimer.Start();
-                    Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect in {interval} seconds...");
+                int interval = webSocket.reconnectAttempts < 50 ? 3 : webSocket.reconnectAttempts < 100 ?  10 : 60;
+                reconnectTimer.Interval = (interval*1000);
+                reconnectTimer.Elapsed += ConnectTimer;
+                reconnectTimer.Start();
+                Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect in {interval} seconds...");
             }
 
             client.CallHook("DiscordSocket_WebSocketClosed", null, e.Reason, e.Code, e.WasClean);

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -51,7 +51,8 @@ namespace Oxide.Ext.Discord.WebSockets
                 var sp = JsonConvert.SerializeObject(payload);
                 webSocket.Send(sp);
 
-            } else
+            }
+            else
             {
                 var payload = new Packet()
                 {
@@ -72,14 +73,14 @@ namespace Oxide.Ext.Discord.WebSockets
             {
                 throw new APIKeyException();
             }
-            
+
             if (!Interface.Oxide.IsShuttingDown)
             {
                 Interface.Oxide.LogWarning($"[Discord Ext] Connection closed.. CODE: {e.Code}");
 
                 webSocket.reconnectAttempts++;
-                int interval = webSocket.reconnectAttempts < 50 ? 3 : webSocket.reconnectAttempts < 100 ?  10 : 60;
-                reconnectTimer.Interval = (interval*1000);
+                int interval = webSocket.reconnectAttempts < 50 ? 3 : webSocket.reconnectAttempts < 100 ? 10 : 60;
+                reconnectTimer.Interval = (interval * 1000);
                 reconnectTimer.Elapsed += ConnectTimer;
                 reconnectTimer.Start();
                 Interface.Oxide.LogWarning($"[Discord Ext] Attempting to reconnect in {interval} seconds...");
@@ -88,7 +89,7 @@ namespace Oxide.Ext.Discord.WebSockets
             client.CallHook("DiscordSocket_WebSocketClosed", null, e.Reason, e.Code, e.WasClean);
         }
 
-        private void ConnectTimer(Object source, System.Timers.ElapsedEventArgs e) 
+        private void ConnectTimer(Object source, System.Timers.ElapsedEventArgs e)
         {
             webSocket.Connect(client.WSSURL);
         }
@@ -113,7 +114,7 @@ namespace Oxide.Ext.Discord.WebSockets
                 {
                     webSocket.lastHeartbeat = 0;
                 }
-                if (webSocket.resume != null) 
+                if (webSocket.resume != null)
                 {
                     webSocket.resume.seq = webSocket.lastHeartbeat;
                 }
@@ -146,7 +147,7 @@ namespace Oxide.Ext.Discord.WebSockets
                             case "RESUMED":
                                 {
                                     Resumed resumed = JsonConvert.DeserializeObject<Resumed>(eventData);
-                                    Interface.Oxide.LogInfo("[Discord Ext] Succesfully resumed session.");
+                                    Interface.Oxide.LogInfo("[Discord Ext] Successfully resumed session.");
                                     client.CallHook("Discord_Resumed", null, resumed);
                                     break;
                                 }

--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -53,7 +53,6 @@ namespace Oxide.Ext.Discord.WebSockets
                     }
                 };
                 var sp = JsonConvert.SerializeObject(payload);
-                Interface.Oxide.LogInfo(sp);
                 webSocket.Send(sp);
 
             } else


### PR DESCRIPTION
Discord recommends that when a connection is dropped that you should resume it rather than creating a new identity every time. You can send 1000 identities every 24 hours.

I also realized that my "auto reconnect" method had no timer on it and thus spamming the websocket connect method and therefore causing API bans.

I have now corrected a few mistakes.. 

- Last heartbeat should be assigned with the Socket so that it can be used for Resuming.
- Last heartbeat was never being assigned a value from [s] in the payload. (this may fix websocket errors?)
- Auto reconnect on a timer.

If there's anything you want me to explain/change feel free to let me know.