### PR TITLE
[SocketListener] Move DiscordSocket_Initialized hook call.

### DIFF
--- a/Oxide.Ext.Discord/WebSockets/SocketListner.cs
+++ b/Oxide.Ext.Discord/WebSockets/SocketListner.cs
@@ -92,7 +92,6 @@ namespace Oxide.Ext.Discord.WebSockets
                         case "READY":
                         {
                             client.UpdatePluginReference();
-                            client.CallHook("DiscordSocket_Initialized");
                             
                             Ready ready = payload.EventData.ToObject<Ready>();
 
@@ -109,7 +108,8 @@ namespace Oxide.Ext.Discord.WebSockets
 
                             client.DiscordServer = ready.Guilds.FirstOrDefault();
                             client.SessionID = ready.SessionID;
-
+                            
+                            client.CallHook("DiscordSocket_Initialized");
                             client.CallHook("Discord_Ready", null, ready);
                             break;
                         }


### PR DESCRIPTION
I have moved the hook call below the assignment of the discord server to the client so that client.DiscordServer is not null when using the hook.