### PR TITLE
Fix for PUT WebRequests

### DIFF
--- a/Oxide.Ext.Discord/REST/Request.cs
+++ b/Oxide.Ext.Discord/REST/Request.cs
@@ -56,6 +56,7 @@
 
             var req = WebRequest.Create(RequestURL);
             req.Method = Method.ToString();
+            req.ContentLength = 0;
             req.Timeout = 5000;
 
             if (this.Headers != null)
@@ -141,7 +142,7 @@
 
         private void WriteRequestData(WebRequest request, object data)
         {
-            string contents = JsonConvert.SerializeObject(Data, new JsonSerializerSettings()
+            string contents = JsonConvert.SerializeObject(data, new JsonSerializerSettings()
             {
                 NullValueHandling = NullValueHandling.Ignore
             });


### PR DESCRIPTION
Content-Length was ommitted for certain put requests, e.g;
Guild.AddGuildMemberRole(...)

Content-Length is now a default set to 0 by default (This is overridden if data != null)

Discord API was returning an error complaining about Content-Length not being set for any Request MethodType != GET.
Even if the payload was empty, the API still wanted to know through a header. If data == null, the WriteRequestData method would never set Content-Length to 0.

Also changed WriteRequestData to start using the object param instead of instance field. OCD was ticking..